### PR TITLE
fix(storage): ensure file name is correctly extracted before deletion…

### DIFF
--- a/src/backend/base/langflow/api/v2/files.py
+++ b/src/backend/base/langflow/api/v2/files.py
@@ -217,7 +217,7 @@ async def delete_files_batch(
 
         # Delete all files from the storage service
         for file in files:
-            await storage_service.delete_file(flow_id=str(current_user.id), file_name=file.path)
+            await storage_service.delete_file(flow_id=str(current_user.id), file_name=file.path.split("/")[-1])
             await session.delete(file)
 
         # Delete all files from the database
@@ -416,7 +416,7 @@ async def delete_file(
             raise HTTPException(status_code=404, detail="File not found")
 
         # Delete the file from the storage service
-        await storage_service.delete_file(flow_id=str(current_user.id), file_name=file.path)
+        await storage_service.delete_file(flow_id=str(current_user.id), file_name=file.path.split("/")[-1])
 
         # Delete from the database
         await session.delete(file)
@@ -446,7 +446,7 @@ async def delete_all_files(
 
         # Delete all files from the storage service
         for file in files:
-            await storage_service.delete_file(flow_id=str(current_user.id), file_name=file.path)
+            await storage_service.delete_file(flow_id=str(current_user.id), file_name=file.path.split("/")[-1])
             await session.delete(file)
 
         # Delete all files from the database

--- a/src/backend/base/langflow/services/storage/local.py
+++ b/src/backend/base/langflow/services/storage/local.py
@@ -103,6 +103,7 @@ class LocalStorageService(StorageService):
         :param file_name: The name of the file to be deleted.
         """
         file_path = self.data_dir / flow_id / file_name
+
         if await file_path.exists():
             await file_path.unlink()
             logger.info(f"File {file_name} deleted successfully from flow {flow_id}.")


### PR DESCRIPTION
….  Previously file.name was used, which included the userID in the file path. This resulted in double inclusion of the userID in the filepath to delete.